### PR TITLE
fix(perf): add tradeId fallback index + harden MongoIndexConfig

### DIFF
--- a/am-trade-app/src/main/resources/application.yml
+++ b/am-trade-app/src/main/resources/application.yml
@@ -37,6 +37,9 @@ am:
 
 server:
   port: 8080
+  tomcat:
+    threads:
+      max: 1000
 
 spring:
   application:

--- a/am-trade-persistence/src/main/java/am/trade/persistence/config/MongoIndexConfig.java
+++ b/am-trade-persistence/src/main/java/am/trade/persistence/config/MongoIndexConfig.java
@@ -20,63 +20,141 @@ public class MongoIndexConfig {
 
     @PostConstruct
     public void createIndexes() {
+        log.info("Creating MongoDB indexes for trade_details collection...");
         IndexOperations tradeOps = mongoTemplate.indexOps(TradeDetailsEntity.class);
+        int created = 0;
+        int failed = 0;
 
-        // Index 0: Powers business key lookups (PUT/POST)
+        // Index 0a: UNIQUE index on tradeId — powers all findByTradeId lookups.
+        // Can fail if duplicate tradeIds exist in the collection (e.g. after load testing
+        // without a unique constraint). The non-unique fallback below (0b) ensures queries
+        // remain fast even in that degraded state.
         try {
             tradeOps.ensureIndex(new Index()
                     .on("tradeId", Sort.Direction.ASC)
                     .named("idx_trade_trade_id")
                     .unique()
                     .background());
+            created++;
+            log.info("[OK] idx_trade_trade_id (unique)");
         } catch (Exception e) {
-            log.warn("Failed to create unique index on tradeId. This is likely because the K6 load test inserted duplicate trades before the index existed. Please clear duplicates from the am-apps-dev database to enable the index.", e);
+            failed++;
+            log.warn("[WARN] idx_trade_trade_id (unique) FAILED — duplicate tradeIds detected. " +
+                     "Run the cleanup script (docs/ops/deduplicate-trade-ids.js) against am-apps-dev " +
+                     "to resolve duplicates and re-enable the unique constraint. " +
+                     "Falling back to non-unique index for query performance.", e);
+        }
+
+        // Index 0b: NON-UNIQUE fallback index on tradeId.
+        // Always created regardless of whether the unique index above succeeded.
+        // Guarantees that findByTradeId() is never a full collection scan (COLLSCAN)
+        // even when duplicates exist.
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("tradeId", Sort.Direction.ASC)
+                    .named("idx_trade_trade_id_lookup")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_trade_id_lookup (non-unique fallback)");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_trade_id_lookup FAILED — trade update/read queries may be slow!", e);
         }
 
         // Index 1: Powers GET /v1/trades/details/portfolio/{portfolioId}
         // Satisfies queries on portfolioId alone (prefix rule)
         // AND queries on portfolioId + symbol (the filtered symbol search)
-        tradeOps.ensureIndex(new Index()
-                .on("portfolioId", Sort.Direction.ASC)
-                .on("symbol", Sort.Direction.ASC)
-                .named("idx_trade_portfolio_symbol")
-                .background());
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("portfolioId", Sort.Direction.ASC)
+                    .on("symbol", Sort.Direction.ASC)
+                    .named("idx_trade_portfolio_symbol")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_portfolio_symbol");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_portfolio_symbol FAILED", e);
+        }
 
         // Index 1b: Powers GET /v2/trades/details/portfolio/{portfolioId}
         // with the new User ID pushdown optimization
-        tradeOps.ensureIndex(new Index()
-                .on("userId", Sort.Direction.ASC)
-                .on("portfolioId", Sort.Direction.ASC)
-                .on("symbol", Sort.Direction.ASC)
-                .named("idx_trade_user_portfolio_symbol")
-                .background());
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("userId", Sort.Direction.ASC)
+                    .on("portfolioId", Sort.Direction.ASC)
+                    .on("symbol", Sort.Direction.ASC)
+                    .named("idx_trade_user_portfolio_symbol")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_user_portfolio_symbol");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_user_portfolio_symbol FAILED", e);
+        }
 
         // Index 2: Powers pagination queries sorted by entry date (most common sort)
-        tradeOps.ensureIndex(new Index()
-                .on("portfolioId", Sort.Direction.ASC)
-                .on("entryInfo.timestamp", Sort.Direction.DESC)
-                .named("idx_trade_portfolio_date")
-                .background());
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("portfolioId", Sort.Direction.ASC)
+                    .on("entryInfo.timestamp", Sort.Direction.DESC)
+                    .named("idx_trade_portfolio_date")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_portfolio_date");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_portfolio_date FAILED", e);
+        }
 
         // Index 3: Powers the Filter API (status is the primary discriminator)
-        tradeOps.ensureIndex(new Index()
-                .on("portfolioId", Sort.Direction.ASC)
-                .on("status", Sort.Direction.ASC)
-                .named("idx_trade_portfolio_status")
-                .background());
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("portfolioId", Sort.Direction.ASC)
+                    .on("status", Sort.Direction.ASC)
+                    .named("idx_trade_portfolio_status")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_portfolio_status");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_portfolio_status FAILED", e);
+        }
 
         // Index 4: Powers Journal/Analytics by user id and date
-        tradeOps.ensureIndex(new Index()
-                .on("userId", Sort.Direction.ASC)
-                .on("entryInfo.timestamp", Sort.Direction.DESC)
-                .named("idx_trade_user_date")
-                .background());
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("userId", Sort.Direction.ASC)
+                    .on("entryInfo.timestamp", Sort.Direction.DESC)
+                    .named("idx_trade_user_date")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_user_date");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_user_date FAILED", e);
+        }
 
         // Index 5: Powers Journal/Analytics by user id and symbol
-        tradeOps.ensureIndex(new Index()
-                .on("userId", Sort.Direction.ASC)
-                .on("symbol", Sort.Direction.ASC)
-                .named("idx_trade_user_symbol")
-                .background());
+        try {
+            tradeOps.ensureIndex(new Index()
+                    .on("userId", Sort.Direction.ASC)
+                    .on("symbol", Sort.Direction.ASC)
+                    .named("idx_trade_user_symbol")
+                    .background());
+            created++;
+            log.info("[OK] idx_trade_user_symbol");
+        } catch (Exception e) {
+            failed++;
+            log.error("[ERROR] idx_trade_user_symbol FAILED", e);
+        }
+
+        if (failed == 0) {
+            log.info("MongoDB index setup complete: {}/{} indexes OK.", created, created + failed);
+        } else {
+            log.warn("MongoDB index setup complete with issues: {}/{} indexes OK, {} FAILED. " +
+                     "Check logs above for details.", created, created + failed, failed);
+        }
     }
 }
+

--- a/am-trade-persistence/src/main/java/am/trade/persistence/config/PersistenceAutoConfiguration.java
+++ b/am-trade-persistence/src/main/java/am/trade/persistence/config/PersistenceAutoConfiguration.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import am.trade.persistence.mapper.PortfolioMapper;
 import am.trade.persistence.mapper.TradeDetailsMapper;
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Auto-configuration class for the persistence module
@@ -31,4 +33,17 @@ public class PersistenceAutoConfiguration {
         return new PortfolioMapper(new TradeDetailsMapper());
     }
 
+    /**
+     * Customize MongoDB client settings for high concurrency
+     */
+    @Bean
+    public MongoClientSettingsBuilderCustomizer customMongoClientSettings() {
+        return builder -> {
+            builder.applyToConnectionPoolSettings(pool -> 
+                pool.maxSize(1000)
+                    .minSize(50)
+                    .maxWaitTime(10, TimeUnit.SECONDS)
+            );
+        };
+    }
 }

--- a/docs/ops/deduplicate-trade-ids.js
+++ b/docs/ops/deduplicate-trade-ids.js
@@ -1,0 +1,85 @@
+/**
+ * deduplicate-trade-ids.js
+ *
+ * Purpose: Remove duplicate tradeId documents from the trade_details collection
+ *          so that the unique index on tradeId can be (re-)created by the application.
+ *
+ * Background: During early load tests, trades were inserted without a unique index
+ *             on tradeId, creating duplicate entries. The application's MongoIndexConfig
+ *             catches this failure and falls back to a non-unique index, but the
+ *             unique constraint cannot be enforced until duplicates are removed.
+ *
+ * Instructions:
+ *   1. Connect to the target MongoDB instance (e.g., via mongosh or MongoDB Compass)
+ *   2. Switch to the correct database: use trade
+ *   3. Run this script: load("deduplicate-trade-ids.js")
+ *
+ * IMPORTANT: Run in DRY_RUN mode first (dryRun = true) to see what would be deleted.
+ *            Only set dryRun = false after reviewing the output and confirming it is safe.
+ *
+ * Environment: am-apps-dev ONLY. Never run against staging or production.
+ */
+
+const DRY_RUN = true; // SAFETY: Set to false to actually delete
+const COLLECTION = "trade_details";
+
+print(`\n=== Trade Deduplication Script ===`);
+print(`Database:   ${db.getName()}`);
+print(`Collection: ${COLLECTION}`);
+print(`Dry Run:    ${DRY_RUN}\n`);
+
+if (DRY_RUN) {
+    print("*** DRY RUN MODE — no data will be modified ***\n");
+}
+
+// Step 1: Find all duplicate tradeIds
+const duplicates = db[COLLECTION].aggregate([
+    {
+        $group: {
+            _id: "$tradeId",
+            count: { $sum: 1 },
+            docIds: { $push: "$_id" }
+        }
+    },
+    {
+        $match: { count: { $gt: 1 } }
+    },
+    {
+        $sort: { count: -1 }
+    }
+]).toArray();
+
+if (duplicates.length === 0) {
+    print("No duplicate tradeIds found. The unique index can be safely created.");
+    print("\nNext step: Restart the application pod to trigger MongoIndexConfig.createIndexes()");
+    print("  kubectl rollout restart deployment/am-trade-management -n am-apps-dev");
+} else {
+    print(`Found ${duplicates.length} tradeId(s) with duplicates:\n`);
+
+    let totalToDelete = 0;
+    duplicates.forEach(dup => {
+        print(`  tradeId: ${dup._id}  |  ${dup.count} copies  |  keeping: ${dup.docIds[0]}  |  deleting: ${dup.count - 1}`);
+        totalToDelete += dup.count - 1;
+    });
+
+    print(`\nTotal documents to remove: ${totalToDelete}`);
+
+    if (!DRY_RUN) {
+        print("\nDeleting duplicates (keeping the first inserted document per tradeId)...");
+
+        let deleted = 0;
+        duplicates.forEach(dup => {
+            const idsToDelete = dup.docIds.slice(1);
+            const result = db[COLLECTION].deleteMany({ _id: { $in: idsToDelete } });
+            deleted += result.deletedCount;
+        });
+
+        print(`\nDeleted ${deleted} duplicate documents.`);
+        print("\nNext step: Restart the application pod to trigger index creation:");
+        print("  kubectl rollout restart deployment/am-trade-management -n am-apps-dev");
+        print("\nThen verify the unique index was created:");
+        print(`  db.${COLLECTION}.getIndexes()`);
+    } else {
+        print(`\nTo apply: set DRY_RUN = false and re-run this script.`);
+    }
+}


### PR DESCRIPTION
The unique index on tradeId was silently failing at startup because duplicate tradeId documents existed in the am-apps-dev database (inserted during early load tests before the unique constraint was in place). This left all findByTradeId() queries as full collection scans (COLLSCAN), causing 20-40s p95 latencies under 200-VU load.

Changes:
- MongoIndexConfig: add non-unique fallback idx_trade_trade_id_lookup that is always ensured regardless of the unique index outcome. This guarantees findByTradeId() is never a COLLSCAN even when duplicates exist.
- MongoIndexConfig: wrap every index in its own try-catch with structured [OK]/[ERROR] logging and a startup summary line for fast triage.
- application.yml: increase Tomcat max threads from default to 1000 to match the connection pool capacity.
- PersistenceAutoConfiguration: raise MongoDB connection pool maxSize to 1000 with a 10s maxWaitTime to handle high-concurrency load.
- docs/ops/deduplicate-trade-ids.js: add operational runbook script to identify and remove duplicate tradeIds so the unique index can be re-enabled after cleanup.

Root cause: duplicate data, not a code logic error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased application capacity for high-concurrency workloads through expanded server and database connection limits.

* **Reliability**
  * Improved database index setup so individual failures no longer prevent other indexes from being created.
  * Added clearer progress and completion reporting for index operations.
  * Added a fallback index to help maintain query performance when the unique trade ID index cannot be created.

* **Operations**
  * Added a utility to identify and optionally remove duplicate trade records, with dry-run support and follow-up recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->